### PR TITLE
Fix/nightvision restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When your contribution is ready to be merged, create a Pull Request and once rea
 
 ### 1.1
 
+-   Restores remaining player night vision duration when disabling command
 -   Added a simple persistent saving feature for other features to utilize
 -   Added the /enchant command that add or removes enchantments from player items
 -   Added the /tptop command that teleports a player upwards to the next safe location

--- a/src/main/java/com/stemcraft/feature/SMNightVision.java
+++ b/src/main/java/com/stemcraft/feature/SMNightVision.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import com.stemcraft.STEMCraft;
 import com.stemcraft.core.SMFeature;
 import com.stemcraft.core.SMMessenger;
 import com.stemcraft.core.SMPersistent;
@@ -13,6 +14,17 @@ import com.stemcraft.core.command.SMCommand;
  * Allows players to enable/disable night vision via command.
  */
 public class SMNightVision extends SMFeature {
+    /**
+     * If the SMPersistent feature is enabled to be used.
+     */
+    private static Boolean persistentEnabled = false;
+
+    /**
+     * Class constructor
+     */
+    public SMNightVision() {
+        loadAfterFeatures.add("SMPersistent");
+    }
 
     /**
      * Enables the night vision feature by registering the command.
@@ -21,6 +33,10 @@ public class SMNightVision extends SMFeature {
      */
     @Override
     protected Boolean onEnable() {
+        if(STEMCraft.featureEnabled("SMPersistent")) {
+            SMNightVision.persistentEnabled = true;
+        }
+        
         new SMCommand("nightvision")
             .alias("nv")
             .permission("stemcraft.command.nightvision")
@@ -43,11 +59,11 @@ public class SMNightVision extends SMFeature {
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
                 if(action.equals("toggle")) {
-                    toggleNightVision(targetPlayer);
+                    SMNightVision.toggleNightVision(targetPlayer);
                 } else if(action.equals("enable")) {
-                    enableNightVision(targetPlayer);
+                    SMNightVision.enableNightVision(targetPlayer);
                 } else if(action.equals("disable")) {
-                    disableNightVision(targetPlayer);
+                    SMNightVision.disableNightVision(targetPlayer);
                 } else {
                     ctx.returnErrorLocale("NIGHTVISION_USAGE");
                 }
@@ -67,7 +83,7 @@ public class SMNightVision extends SMFeature {
         UUID playerUUID = player.getUniqueId();
 
         // Save any current nightvision
-        if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION) && !SMPersistent.exists(SMNightVision.class, playerUUID.toString())) {
+        if (persistentEnabled && player.hasPotionEffect(PotionEffectType.NIGHT_VISION) && !SMPersistent.exists(SMNightVision.class, playerUUID.toString())) {
             for (PotionEffect effect : player.getActivePotionEffects()) {
                 if (effect.getType() == PotionEffectType.NIGHT_VISION) {
                     SMPersistent.set(SMNightVision.class, playerUUID.toString(), effect);
@@ -92,7 +108,7 @@ public class SMNightVision extends SMFeature {
         player.removePotionEffect(PotionEffectType.NIGHT_VISION);
 
         // Restore any previous nightvision
-        if(SMPersistent.exists(SMNightVision.class, playerUUID.toString())) {
+        if(persistentEnabled && SMPersistent.exists(SMNightVision.class, playerUUID.toString())) {
             player.addPotionEffect(SMPersistent.getObject(SMNightVision.class, playerUUID.toString(), PotionEffect.class));
             SMPersistent.clear(SMNightVision.class, playerUUID.toString());
         }
@@ -124,7 +140,10 @@ public class SMNightVision extends SMFeature {
         UUID playerUUID = player.getUniqueId();
 
         if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION)) {
-            SMPersistent.clear(SMNightVision.class, playerUUID.toString());
+            if(persistentEnabled) {
+                SMPersistent.clear(SMNightVision.class, playerUUID.toString());
+            }
+
             player.removePotionEffect(PotionEffectType.NIGHT_VISION);
         }
     }

--- a/src/main/java/com/stemcraft/feature/SMNightVision.java
+++ b/src/main/java/com/stemcraft/feature/SMNightVision.java
@@ -123,7 +123,14 @@ public class SMNightVision extends SMFeature {
      * @param player The player for whom the night vision effect is to be toggled.
      */
     public static void toggleNightVision(Player player) {
-        if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION)) {
+        Boolean hasState = true;
+
+        if(persistentEnabled) {
+            UUID playerUUID = player.getUniqueId();
+            hasState = SMPersistent.exists(SMNightVision.class, playerUUID.toString());
+        }
+
+        if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION) && hasState) {
             disableNightVision(player);
         } else {
             enableNightVision(player);

--- a/src/main/java/com/stemcraft/feature/SMNightVision.java
+++ b/src/main/java/com/stemcraft/feature/SMNightVision.java
@@ -1,49 +1,131 @@
 package com.stemcraft.feature;
 
+import java.util.UUID;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import com.stemcraft.core.SMFeature;
 import com.stemcraft.core.SMMessenger;
+import com.stemcraft.core.SMPersistent;
 import com.stemcraft.core.command.SMCommand;
 
+/**
+ * Allows players to enable/disable night vision via command.
+ */
 public class SMNightVision extends SMFeature {
+
     /**
-     * When the feature is enabled
+     * Enables the night vision feature by registering the command.
+     *
+     * @return true if the feature is successfully enabled, otherwise false.
      */
     @Override
     protected Boolean onEnable() {
         new SMCommand("nightvision")
             .alias("nv")
-            .permission("stemcraft.nightvision")
+            .permission("stemcraft.command.nightvision")
+            .tabComplete("enable", "{player}")
+            .tabComplete("disable", "{player}")
+            .tabComplete("toggle", "{player}")
             .action(ctx -> {
-                // if (!(sender instanceof Player)) {
-                //     this.plugin.getLanguageManager().sendPhrase(sender, "CMD_ONLY_PLAYERS");
-                //     return true;
-                // }
+                Player targetPlayer = ctx.getArgAsPlayer(2, ctx.player);
+                String action = "toggle";
 
-                toggleNightVision((Player)ctx.sender);
+                // get action (if exists)
+                if(ctx.args.length > 0) {
+                    action = ctx.args[0].toLowerCase();
+                }
+
+                // Check player exists when issued from console
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length == 2), "CMD_PLAYER_REQ_FROM_CONSOLE");
+
+                // Check target player exists
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                if(action.equals("toggle")) {
+                    toggleNightVision(targetPlayer);
+                } else if(action.equals("enable")) {
+                    enableNightVision(targetPlayer);
+                } else if(action.equals("disable")) {
+                    disableNightVision(targetPlayer);
+                } else {
+                    ctx.returnErrorLocale("NIGHTVISION_USAGE");
+                }
             })
             .register();
 
         return true;
     }
 
-    private void enableNightVision(Player player) {
+    /**
+     * Enables night vision effect for the specified player. If the player already has
+     * a night vision effect, it's saved before applying the new effect.
+     *
+     * @param player The player for whom the night vision effect is to be enabled.
+     */
+    public static void enableNightVision(Player player) {
+        UUID playerUUID = player.getUniqueId();
+
+        // Save any current nightvision
+        if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION) && !SMPersistent.exists(SMNightVision.class, playerUUID.toString())) {
+            for (PotionEffect effect : player.getActivePotionEffects()) {
+                if (effect.getType() == PotionEffectType.NIGHT_VISION) {
+                    SMPersistent.set(SMNightVision.class, playerUUID.toString(), effect);
+                    break;
+                }
+            }
+        }
+
         player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0, false, false));
         SMMessenger.infoLocale(player, "NIGHTVISION_ENABLED");
     }
 
-    private void disableNightVision(Player player) {
+    /**
+     * Disables night vision effect for the specified player. If the player had a previously
+     * saved night vision effect, it's restored after removing the current effect.
+     *
+     * @param player The player for whom the night vision effect is to be disabled.
+     */
+    public static void disableNightVision(Player player) {
+        UUID playerUUID = player.getUniqueId();
+
         player.removePotionEffect(PotionEffectType.NIGHT_VISION);
+
+        // Restore any previous nightvision
+        if(SMPersistent.exists(SMNightVision.class, playerUUID.toString())) {
+            player.addPotionEffect(SMPersistent.getObject(SMNightVision.class, playerUUID.toString(), PotionEffect.class));
+            SMPersistent.clear(SMNightVision.class, playerUUID.toString());
+        }
+
         SMMessenger.infoLocale(player, "NIGHTVISION_DISABLED");
     }
 
-    private void toggleNightVision(Player player) {
+    /**
+     * Toggles the night vision effect for the specified player. If the player currently has
+     * the effect, it's disabled, otherwise, it's enabled.
+     *
+     * @param player The player for whom the night vision effect is to be toggled.
+     */
+    public static void toggleNightVision(Player player) {
         if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION)) {
             disableNightVision(player);
         } else {
             enableNightVision(player);
+        }
+    }
+
+    /**
+     * Clears the night vision effect for the specified player without restoring any 
+     * previously saved effects.
+     *
+     * @param player The player for whom the night vision effect is to be cleared.
+     */
+    public static void clearNightVision(Player player) {
+        UUID playerUUID = player.getUniqueId();
+
+        if (player.hasPotionEffect(PotionEffectType.NIGHT_VISION)) {
+            SMPersistent.clear(SMNightVision.class, playerUUID.toString());
+            player.removePotionEffect(PotionEffectType.NIGHT_VISION);
         }
     }
 }

--- a/src/main/resources/messages_en.yml
+++ b/src/main/resources/messages_en.yml
@@ -46,6 +46,7 @@ BOOK_DELETE_SUCCESSFUL: "Book deleted"
 
 WAYSTONE_NONE_FOUND: "No waystones found nearby"
 
+NIGHTVISION_USAGE: "Usage: /nightvision (toggle|enable|disable) (<player>)"
 NIGHTVISION_ENABLED: "Night vision enabled"
 NIGHTVISION_DISABLED: "Night vision disabled"
 


### PR DESCRIPTION
This PR adds an action (toggle*|enable|disable) parameter to the command as well as a player name to perform in the command on another player. (*default)

Now enforces a player and action when run from the console.

Will restore previous night vision effect when disabled, if one was present when the player enabled it.

Nightvision methods within the class are now public to allow other features to manipulate player states. This plugin now requires the SMPersistent feature (#14) to be enabled to store states across server restarts.

**BREAKING CHANGES**
The permission has been changed from `stemcraft.nightvision` to `stemcraft.command.nightvision` to be inline with other permission structures used in the plugin.
