### PR TITLE
Adds various workbench commands for players 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When your contribution is ready to be merged, create a Pull Request and once rea
 
 ### 1.1
 
+-   Added workbench commands /anvil, /cartographytable, /grindstone, /loom, /smithingtable, /stonecutter
 -   Restores remaining player night vision duration when disabling command
 -   Added a simple persistent saving feature for other features to utilize
 -   Added the /enchant command that add or removes enchantments from player items

--- a/src/main/java/com/stemcraft/core/SMBridge.java
+++ b/src/main/java/com/stemcraft/core/SMBridge.java
@@ -4,11 +4,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import org.bukkit.NamespacedKey;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.command.CommandMap;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
 import com.stemcraft.STEMCraft;
 import com.stemcraft.core.exception.SMBridgeException;
 import lombok.NonNull;
@@ -192,5 +195,92 @@ public final class SMBridge {
         }
 
         return Enchantment.getByName(name.toUpperCase());
+    }
+
+    /**
+     * Opens a specific type of inventory for the player, or falls back to a default inventory if the specific inventory
+     * opening method is not available.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param type The type of inventory to open.
+     * @param methodName The name of the method to invoke for opening the inventory.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    private static void openInventory(Player player, InventoryType type, String methodName, Location location,
+        Boolean force) {
+        try {
+            Class<?> playerClass = org.bukkit.entity.Player.class;
+            Method method = playerClass.getMethod(methodName, org.bukkit.Location.class, boolean.class);
+            method.invoke(player, location, force);
+        } catch (Exception e) {
+            player.openInventory(Bukkit.createInventory(player, type));
+        }
+    }
+
+    /**
+     * Opens an Anvil inventory for the player.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    public static void openAnvil(Player player, Location location, Boolean force) {
+        openInventory(player, InventoryType.ANVIL, "openAnvil", location, force);
+    }
+
+    /**
+     * Opens a Cartography Table inventory for the player.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    public static void openCartographyTable(Player player, Location location, Boolean force) {
+        openInventory(player, InventoryType.CARTOGRAPHY, "openCartographyTable", location, force);
+    }
+
+    /**
+     * Opens a Grindstone inventory for the player.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    public static void openGrindstone(Player player, Location location, Boolean force) {
+        openInventory(player, InventoryType.GRINDSTONE, "openGrindstone", location, force);
+    }
+
+    /**
+     * Opens a Loom inventory for the player.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    public static void openLoom(Player player, Location location, Boolean force) {
+        openInventory(player, InventoryType.LOOM, "openLoom", location, force);
+    }
+
+    /**
+     * Opens a Smithing table inventory for the player.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    public static void openSmithingTable(Player player, Location location, Boolean force) {
+        openInventory(player, InventoryType.SMITHING, "openSmithingTable", location, force);
+    }
+
+    /**
+     * Opens a Stonecutter inventory for the player.
+     *
+     * @param player The player for whom the inventory should be opened.
+     * @param location The location for the inventory (if applicable).
+     * @param force A boolean indicating whether to force the opening of the inventory (if applicable).
+     */
+    public static void openStonecutter(Player player, Location location, Boolean force) {
+        openInventory(player, InventoryType.STONECUTTER, "openStonecutter", location, force);
     }
 }

--- a/src/main/java/com/stemcraft/feature/SMWorkbench.java
+++ b/src/main/java/com/stemcraft/feature/SMWorkbench.java
@@ -20,10 +20,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.workbench")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.workbench.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.workbench.other");
 
                 targetPlayer.openWorkbench(null, true);
             })
@@ -34,10 +36,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.anvil")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.anvil.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.anvil.other");
 
                 SMBridge.openAnvil(targetPlayer, null, true);
             })
@@ -48,10 +52,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.cartographytable")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.cartographytable.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.cartographytable.other");
 
                 SMBridge.openCartographyTable(targetPlayer, null, true);
             })
@@ -62,10 +68,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.grindstone")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.grindstone.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.grindstone.other");
 
                 SMBridge.openGrindstone(targetPlayer, null, true);
             })
@@ -76,10 +84,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.loom")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.loom.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.loom.other");
 
                 SMBridge.openLoom(targetPlayer, null, true);
             })
@@ -90,10 +100,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.smithingtable")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.smithingtable.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.smithingtable.other");
 
                 SMBridge.openSmithingTable(targetPlayer, null, true);
             })
@@ -104,10 +116,12 @@ public class SMWorkbench extends SMFeature {
             .permission("stemcraft.command.stonecutter")
             .action(ctx -> {
                 ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
-                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.stonecutter.other");
 
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                ctx.checkPermission(ctx.fromConsole() || targetPlayer.getUniqueId().equals(ctx.player.getUniqueId()),
+                    "stemcraft.command.stonecutter.other");
 
                 SMBridge.openStonecutter(targetPlayer, null, true);
             })

--- a/src/main/java/com/stemcraft/feature/SMWorkbench.java
+++ b/src/main/java/com/stemcraft/feature/SMWorkbench.java
@@ -1,0 +1,133 @@
+package com.stemcraft.feature;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.BookMeta;
+import com.stemcraft.core.SMCommon;
+import com.stemcraft.core.SMDatabase;
+import com.stemcraft.core.SMFeature;
+import com.stemcraft.core.SMMessenger;
+import com.stemcraft.core.command.SMCommand;
+import com.stemcraft.core.tabcomplete.SMTabComplete;
+
+/**
+ * Allows the player to open workbenches on command
+ */
+public class SMWorkbench extends SMFeature {
+
+    /**
+     * When feature is enabled
+     */
+    @Override
+    protected Boolean onEnable() {
+        new SMCommand("workbench")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.workbench")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.workbench.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openWorkbench(null, true);
+            })
+            .register();
+
+        new SMCommand("anvil")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.anvil")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.anvil.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openAnvil(null, true);
+            })
+            .register();
+
+        new SMCommand("cartographytable")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.cartographytable")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.cartographytable.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openCartographyTable(null, true);
+            })
+            .register();
+
+        new SMCommand("grindstone")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.grindstone")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.grindstone.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openGrindstone(null, true);
+            })
+            .register();
+
+        new SMCommand("loom")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.loom")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.loom.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openLoom(null, true);
+            })
+            .register();
+
+        new SMCommand("smithingtable")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.smithingtable")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.smithingtable.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openSmithingTable(null, true);
+            })
+            .register();
+
+        new SMCommand("stonecutter")
+            .tabComplete("{player}")
+            .permission("stemcraft.command.stonecutter")
+            .action(ctx -> {
+                ctx.checkBooleanLocale(!(ctx.fromConsole() && ctx.args.length < 1), "CMD_PLAYER_REQ_FROM_CONSOLE");
+                ctx.checkPermission(ctx.args.length == 0, "stemcraft.command.stonecutter.other");
+
+                Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
+                ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
+
+                targetPlayer.openStonecutter(null, true);
+            })
+            .register();
+
+        return true;
+    }
+}

--- a/src/main/java/com/stemcraft/feature/SMWorkbench.java
+++ b/src/main/java/com/stemcraft/feature/SMWorkbench.java
@@ -1,24 +1,9 @@
 package com.stemcraft.feature;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.BookMeta;
-import com.stemcraft.core.SMCommon;
-import com.stemcraft.core.SMDatabase;
+import com.stemcraft.core.SMBridge;
 import com.stemcraft.core.SMFeature;
-import com.stemcraft.core.SMMessenger;
 import com.stemcraft.core.command.SMCommand;
-import com.stemcraft.core.tabcomplete.SMTabComplete;
 
 /**
  * Allows the player to open workbenches on command
@@ -54,7 +39,7 @@ public class SMWorkbench extends SMFeature {
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
-                targetPlayer.openAnvil(null, true);
+                SMBridge.openAnvil(targetPlayer, null, true);
             })
             .register();
 
@@ -68,7 +53,7 @@ public class SMWorkbench extends SMFeature {
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
-                targetPlayer.openCartographyTable(null, true);
+                SMBridge.openCartographyTable(targetPlayer, null, true);
             })
             .register();
 
@@ -82,7 +67,7 @@ public class SMWorkbench extends SMFeature {
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
-                targetPlayer.openGrindstone(null, true);
+                SMBridge.openGrindstone(targetPlayer, null, true);
             })
             .register();
 
@@ -96,7 +81,7 @@ public class SMWorkbench extends SMFeature {
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
-                targetPlayer.openLoom(null, true);
+                SMBridge.openLoom(targetPlayer, null, true);
             })
             .register();
 
@@ -110,7 +95,7 @@ public class SMWorkbench extends SMFeature {
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
-                targetPlayer.openSmithingTable(null, true);
+                SMBridge.openSmithingTable(targetPlayer, null, true);
             })
             .register();
 
@@ -124,7 +109,7 @@ public class SMWorkbench extends SMFeature {
                 Player targetPlayer = ctx.getArgAsPlayer(1, ctx.player);
                 ctx.checkNotNullLocale(targetPlayer, "CMD_PLAYER_NOT_FOUND");
 
-                targetPlayer.openStonecutter(null, true);
+                SMBridge.openStonecutter(targetPlayer, null, true);
             })
             .register();
 


### PR DESCRIPTION
Adds the following commands. Each requires the permission `stemmcraft.command.<cmd>`. To run the command on another player, requires the permission `stemcraft.command.<cmd>.other`


```
/workbench ({player})
/anvil ({player})
/cartographytable ({player})
/grindstone ({player})
/loom ({player})
/smithingtable ({player})
/stonecutter ({player})
```