### PR TITLE
Add configuration sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ When your contribution is ready to be merged, create a Pull Request and once rea
 
 -   Added `/t` to direct message a player
 -   Added chat/sign/book filtering
+-   Added support for retrieving a list of root keys in config files
+-   Added `addMissingDefaultValues` to allow syncing default/user config files
+-   Server locale files will now append missing strings when added in future versions
 
 ### 1.1.0
 

--- a/src/main/java/com/stemcraft/core/SMLocale.java
+++ b/src/main/java/com/stemcraft/core/SMLocale.java
@@ -36,7 +36,9 @@ public class SMLocale {
             if (fileName.startsWith(prefix) && fileName.endsWith(extension)) {
                 String locale = fileName.substring(prefix.length(), fileName.length() - extension.length());
                 STEMCraft.info("Loaded built-in locale: " + locale);
-                localeFiles.put(locale, new SMConfigFile(fileName));
+                SMConfigFile localeFile = new SMConfigFile(fileName);
+                localeFile.addMissingDefaultValues();
+                localeFiles.put(locale, localeFile);
             }
         });
 
@@ -51,8 +53,8 @@ public class SMLocale {
                     if (!localeFiles.containsKey(locale)) {
                         STEMCraft.info("Replaced locale: " + locale);
                         SMConfigFile localeFile = new SMConfigFile(fileName);
-                        localeFiles.put(locale, localeFile);
                         localeFile.addMissingDefaultValues();
+                        localeFiles.put(locale, localeFile);
                     }
                 }
             }

--- a/src/main/java/com/stemcraft/core/SMLocale.java
+++ b/src/main/java/com/stemcraft/core/SMLocale.java
@@ -50,7 +50,9 @@ public class SMLocale {
                     String locale = fileName.substring(prefix.length(), fileName.length() - extension.length());
                     if (!localeFiles.containsKey(locale)) {
                         STEMCraft.info("Replaced locale: " + locale);
-                        localeFiles.put(locale, new SMConfigFile(fileName));
+                        SMConfigFile localeFile = new SMConfigFile(fileName);
+                        localeFiles.put(locale, localeFile);
+                        localeFile.addMissingDefaultValues();
                     }
                 }
             }

--- a/src/main/java/com/stemcraft/core/config/SMConfigFile.java
+++ b/src/main/java/com/stemcraft/core/config/SMConfigFile.java
@@ -636,9 +636,16 @@ public class SMConfigFile {
     }
 
     /**
+     * Will add any missing default root values to a user configuration file.
+     */
+    public void addMissingDefaultValues() {
+        addMissingDefaultValues(null);
+    }
+
+    /**
      * Will add any missing default values to a user configuration file.
      * 
-     * @param key The key to add from.
+     * @param key The key to add from, null for root
      */
     public void addMissingDefaultValues(String key) {
         List<String> defaultKeys = getDefaultKeys(key);

--- a/src/main/java/com/stemcraft/core/config/SMConfigFile.java
+++ b/src/main/java/com/stemcraft/core/config/SMConfigFile.java
@@ -590,22 +590,48 @@ public class SMConfigFile {
     }
 
     /**
+     * Fetches a list of keys from the root.
+     *
+     * @return A list of string keys.
+     */
+    public List<String> getKeys() {
+        return getKeys(null);
+    }
+
+    /**
      * Fetches a list of keys from a path.
      *
-     * @param key The path to fetch keys.
+     * @param key The path to fetch keys, null for root.
      * @return A list of string keys.
      */
     public List<String> getKeys(String key) {
+        if (key == null) {
+            return SMCommon.setToList(file.getKeys());
+        }
+
         return SMCommon.setToList(file.getSection(key).getKeys());
+    }
+
+    /**
+     * Fetches a list of default keys from the root.
+     *
+     * @return A list of string keys.
+     */
+    public List<String> getDefaultKeys() {
+        return getDefaultKeys(null);
     }
 
     /**
      * Fetches a list of default keys from a path.
      *
-     * @param key The path to fetch default keys.
+     * @param key The path to fetch default keys, null for root.
      * @return A list of string keys.
      */
     public List<String> getDefaultKeys(String key) {
+        if (key == null) {
+            return SMCommon.setToList(defaults.getKeys());
+        }
+
         return SMCommon.setToList(defaults.getSection(key).getKeys());
     }
 

--- a/src/main/java/com/stemcraft/core/config/SMConfigFile.java
+++ b/src/main/java/com/stemcraft/core/config/SMConfigFile.java
@@ -598,4 +598,32 @@ public class SMConfigFile {
     public List<String> getKeys(String key) {
         return SMCommon.setToList(file.getSection(key).getKeys());
     }
+
+    /**
+     * Fetches a list of default keys from a path.
+     *
+     * @param key The path to fetch default keys.
+     * @return A list of string keys.
+     */
+    public List<String> getDefaultKeys(String key) {
+        return SMCommon.setToList(defaults.getSection(key).getKeys());
+    }
+
+    /**
+     * Will add any missing default values to a user configuration file.
+     * 
+     * @param key The key to add from.
+     */
+    public void addMissingDefaultValues(String key) {
+        List<String> defaultKeys = getDefaultKeys(key);
+        if (defaultKeys == null) {
+            return;
+        }
+
+        defaultKeys.removeAll(getKeys(key));
+
+        for (String defaultKey : defaultKeys) {
+            file.set(defaultKey, defaults.get(defaultKey));
+        }
+    }
 }

--- a/src/main/java/com/stemcraft/core/config/SMConfigFile.java
+++ b/src/main/java/com/stemcraft/core/config/SMConfigFile.java
@@ -654,9 +654,17 @@ public class SMConfigFile {
         }
 
         defaultKeys.removeAll(getKeys(key));
+        System.out.println(String.join(",", defaultKeys));
 
         for (String defaultKey : defaultKeys) {
             file.set(defaultKey, defaults.get(defaultKey));
+            System.out.println(defaultKey);
+        }
+
+        try {
+            file.save();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
Adds a method that will add missing configuration options from the file in the plugin resources in the file in the data folder