### PR TITLE
Update MVN action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,8 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
+        cache-dependency-path: | # optional
+          pom.xml
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,13 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4.1.7
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4.2.1
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 


### PR DESCRIPTION
Updates the versions of various actions in maven.yml and forced the setup-java action is cache dependencies (which it wasn't doing previously)